### PR TITLE
Tw menu item review edit page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,6 +15,10 @@ import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
 
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
+import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
+
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
@@ -93,6 +97,29 @@ function App() {
               exact
               path="/placeholder/create"
               element={<PlaceholderCreatePage />}
+            />
+          </>
+        )}
+        {hasRole(currentUser, "ROLE_USER") && (
+          <>
+            <Route
+              exact
+              path="/MenuItemReviews"
+              element={<MenuItemReviewIndexPage />}
+            />
+          </>
+        )}
+        {hasRole(currentUser, "ROLE_ADMIN") && (
+          <>
+            <Route
+              exact
+              path="/MenuItemReviews/edit/:id"
+              element={<MenuItemReviewEditPage />}
+            />
+            <Route
+              exact
+              path="/MenuItemReviews/create"
+              element={<MenuItemReviewCreatePage />}
             />
           </>
         )}

--- a/frontend/src/fixtures/menuItemReviewFixtures.js
+++ b/frontend/src/fixtures/menuItemReviewFixtures.js
@@ -1,0 +1,39 @@
+const menuItemReviewFixtures = {
+    oneMenuItemReview:
+    {
+        "id": 2,
+        "itemId": 1,
+        "reviewerEmail": "tyler_wong@ucsb.edu",
+        "stars": 4,
+        "dateReviewed": "2025-04-26T04:18:01.047",
+        "comments": "Quite good."
+    },
+    threeMenuItemReviews: [
+        {
+            "id": 2,
+            "itemId": 1,
+            "reviewerEmail": "tyler_wong@ucsb.edu",
+            "stars": 4,
+            "dateReviewed": "2025-04-26T04:18:01.047",
+            "comments": "Quite good."
+        },
+        {
+            "id": 3,
+            "itemId": 2,
+            "reviewerEmail": "tyler_w0ng@ucsb.edu",
+            "stars": 5,
+            "dateReviewed": "2025-04-26T03:18:01.047",
+            "comments": "Very good."
+        },
+        {
+            "id": 4,
+            "itemId": 5,
+            "reviewerEmail": "tylerwong@ucsb.edu",
+            "stars": 1,
+            "dateReviewed": "2025-04-26T03:18:01.046",
+            "comments": "Very bad."
+        }
+    ],
+};
+
+export { menuItemReviewFixtures };

--- a/frontend/src/fixtures/menuItemReviewFixtures.js
+++ b/frontend/src/fixtures/menuItemReviewFixtures.js
@@ -1,39 +1,38 @@
 const menuItemReviewFixtures = {
-    oneMenuItemReview:
+  oneMenuItemReview: {
+    id: 2,
+    itemId: 1,
+    reviewerEmail: "tyler_wong@ucsb.edu",
+    stars: 4,
+    dateReviewed: "2025-04-26T04:18:01.047",
+    comments: "Quite good.",
+  },
+  threeMenuItemReviews: [
     {
-        "id": 2,
-        "itemId": 1,
-        "reviewerEmail": "tyler_wong@ucsb.edu",
-        "stars": 4,
-        "dateReviewed": "2025-04-26T04:18:01.047",
-        "comments": "Quite good."
+      id: 2,
+      itemId: 1,
+      reviewerEmail: "tyler_wong@ucsb.edu",
+      stars: 4,
+      dateReviewed: "2025-04-26T04:18:01.047",
+      comments: "Quite good.",
     },
-    threeMenuItemReviews: [
-        {
-            "id": 2,
-            "itemId": 1,
-            "reviewerEmail": "tyler_wong@ucsb.edu",
-            "stars": 4,
-            "dateReviewed": "2025-04-26T04:18:01.047",
-            "comments": "Quite good."
-        },
-        {
-            "id": 3,
-            "itemId": 2,
-            "reviewerEmail": "tyler_w0ng@ucsb.edu",
-            "stars": 5,
-            "dateReviewed": "2025-04-26T03:18:01.047",
-            "comments": "Very good."
-        },
-        {
-            "id": 4,
-            "itemId": 5,
-            "reviewerEmail": "tylerwong@ucsb.edu",
-            "stars": 1,
-            "dateReviewed": "2025-04-26T03:18:01.046",
-            "comments": "Very bad."
-        }
-    ],
+    {
+      id: 3,
+      itemId: 2,
+      reviewerEmail: "tyler_w0ng@ucsb.edu",
+      stars: 5,
+      dateReviewed: "2025-04-26T03:18:01.047",
+      comments: "Very good.",
+    },
+    {
+      id: 4,
+      itemId: 5,
+      reviewerEmail: "tylerwong@ucsb.edu",
+      stars: 1,
+      dateReviewed: "2025-04-26T03:18:01.046",
+      comments: "Very bad.",
+    },
+  ],
 };
 
 export { menuItemReviewFixtures };

--- a/frontend/src/main/components/MenuItemReviews/MenuItemReviewForm.js
+++ b/frontend/src/main/components/MenuItemReviews/MenuItemReviewForm.js
@@ -7,12 +7,19 @@ function MenuItemReviewForm({
   submitAction,
   buttonLabel = "Create",
 }) {
+  const defaultValues = initialContents
+    ? {
+        ...initialContents,
+        dateReviewed: initialContents.dateReviewed,
+      }
+    : {};
+
   // Stryker disable all
   const {
     register,
     formState: { errors },
     handleSubmit,
-  } = useForm({ defaultValues: initialContents || {} });
+  } = useForm({ defaultValues });
   // Stryker restore all
 
   const navigate = useNavigate();
@@ -44,7 +51,7 @@ function MenuItemReviewForm({
       )}
 
       <Form.Group className="mb-3">
-        <Form.Label htmlFor="itemId">itemId</Form.Label>
+        <Form.Label htmlFor="itemId">ItemId</Form.Label>
         <Form.Control
           data-testid={testIdPrefix + "-itemId"}
           id="itemId"
@@ -60,7 +67,7 @@ function MenuItemReviewForm({
       </Form.Group>
 
       <Form.Group className="mb-3">
-        <Form.Label htmlFor="reviewerEmail">reviewEmail</Form.Label>
+        <Form.Label htmlFor="reviewerEmail">Reviewer Email</Form.Label>
         <Form.Control
           data-testid={testIdPrefix + "-reviewerEmail"}
           id="reviewerEmail"
@@ -92,7 +99,9 @@ function MenuItemReviewForm({
       </Form.Group>
 
       <Form.Group className="mb-3">
-        <Form.Label htmlFor="dateReviewed">Date Reviewed (iso format)</Form.Label>
+        <Form.Label htmlFor="dateReviewed">
+          Date Reviewed (iso format)
+        </Form.Label>
         <Form.Control
           data-testid={testIdPrefix + "-dateReviewed"}
           id="dateReviewed"

--- a/frontend/src/main/components/MenuItemReviews/MenuItemReviewForm.js
+++ b/frontend/src/main/components/MenuItemReviews/MenuItemReviewForm.js
@@ -1,0 +1,84 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+
+function MenuItemReviewForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  const testIdPrefix = "MenuItemReviewForm";
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      {initialContents && (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="id">Id</Form.Label>
+          <Form.Control
+            data-testid={testIdPrefix + "-id"}
+            id="id"
+            type="text"
+            {...register("id")}
+            value={initialContents.id}
+            disabled
+          />
+        </Form.Group>
+      )}
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="itemId">itemId</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-itemId"}
+          id="itemId"
+          type="number"
+          isInvalid={Boolean(errors.name)}
+          {...register("itemId", {
+            required: "ItemId is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.itemId?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="reviewerEmail">reviewEmail</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-reviewerEmail"}
+          id="reviewerEmail"
+          type="text"
+          isInvalid={Boolean(errors.description)}
+          {...register("reviewerEmail", {
+            required: "ReviewerEmail is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.reviewerEmail?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={testIdPrefix + "-cancel"}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default MenuItemReviewForm;

--- a/frontend/src/main/components/MenuItemReviews/MenuItemReviewForm.js
+++ b/frontend/src/main/components/MenuItemReviews/MenuItemReviewForm.js
@@ -122,9 +122,7 @@ function MenuItemReviewForm({
         </Form.Control.Feedback>
       </Form.Group>
 
-      <Button type="submit">
-        {buttonLabel}
-      </Button>
+      <Button type="submit">{buttonLabel}</Button>
       <Button
         variant="Secondary"
         onClick={() => navigate(-1)}

--- a/frontend/src/main/components/MenuItemReviews/MenuItemReviewForm.js
+++ b/frontend/src/main/components/MenuItemReviews/MenuItemReviewForm.js
@@ -7,12 +7,7 @@ function MenuItemReviewForm({
   submitAction,
   buttonLabel = "Create",
 }) {
-  const defaultValues = initialContents
-    ? {
-        ...initialContents,
-        dateReviewed: initialContents.dateReviewed,
-      }
-    : {};
+  const defaultValues = initialContents;
 
   // Stryker disable all
   const {
@@ -53,7 +48,6 @@ function MenuItemReviewForm({
       <Form.Group className="mb-3">
         <Form.Label htmlFor="itemId">ItemId</Form.Label>
         <Form.Control
-          data-testid={testIdPrefix + "-itemId"}
           id="itemId"
           type="number"
           isInvalid={Boolean(errors.name)}
@@ -69,7 +63,6 @@ function MenuItemReviewForm({
       <Form.Group className="mb-3">
         <Form.Label htmlFor="reviewerEmail">Reviewer Email</Form.Label>
         <Form.Control
-          data-testid={testIdPrefix + "-reviewerEmail"}
           id="reviewerEmail"
           type="text"
           isInvalid={Boolean(errors.description)}
@@ -85,7 +78,6 @@ function MenuItemReviewForm({
       <Form.Group className="mb-3">
         <Form.Label htmlFor="stars">Stars</Form.Label>
         <Form.Control
-          data-testid={testIdPrefix + "-stars"}
           id="stars"
           type="number"
           isInvalid={Boolean(errors.description)}
@@ -106,7 +98,6 @@ function MenuItemReviewForm({
           data-testid={testIdPrefix + "-dateReviewed"}
           id="dateReviewed"
           type="datetime-local"
-          isInvalid={Boolean(errors.dateReviewed)}
           {...register("dateReviewed", {
             required: true,
             pattern: isodate_regex,
@@ -120,7 +111,6 @@ function MenuItemReviewForm({
       <Form.Group className="mb-3">
         <Form.Label htmlFor="comments">Comments</Form.Label>
         <Form.Control
-          data-testid={testIdPrefix + "-comments"}
           id="comments"
           type="text"
           isInvalid={Boolean(errors.description)}
@@ -133,7 +123,7 @@ function MenuItemReviewForm({
         </Form.Control.Feedback>
       </Form.Group>
 
-      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+      <Button type="submit">
         {buttonLabel}
       </Button>
       <Button

--- a/frontend/src/main/components/MenuItemReviews/MenuItemReviewForm.js
+++ b/frontend/src/main/components/MenuItemReviews/MenuItemReviewForm.js
@@ -95,7 +95,6 @@ function MenuItemReviewForm({
           Date Reviewed (iso format)
         </Form.Label>
         <Form.Control
-          data-testid={testIdPrefix + "-dateReviewed"}
           id="dateReviewed"
           type="datetime-local"
           {...register("dateReviewed", {

--- a/frontend/src/main/components/MenuItemReviews/MenuItemReviewForm.js
+++ b/frontend/src/main/components/MenuItemReviews/MenuItemReviewForm.js
@@ -19,6 +19,14 @@ function MenuItemReviewForm({
 
   const testIdPrefix = "MenuItemReviewForm";
 
+  // For explanation, see: https://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime
+  // Note that even this complex regex may still need some tweaks
+
+  // Stryker disable Regex
+  const isodate_regex =
+    /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
+  // Stryker restore Regex
+
   return (
     <Form onSubmit={handleSubmit(submitAction)}>
       {initialContents && (
@@ -64,6 +72,55 @@ function MenuItemReviewForm({
         />
         <Form.Control.Feedback type="invalid">
           {errors.reviewerEmail?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="stars">Stars</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-stars"}
+          id="stars"
+          type="number"
+          isInvalid={Boolean(errors.description)}
+          {...register("stars", {
+            required: "Stars is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.stars?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="dateReviewed">Date Reviewed (iso format)</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-dateReviewed"}
+          id="dateReviewed"
+          type="datetime-local"
+          isInvalid={Boolean(errors.dateReviewed)}
+          {...register("dateReviewed", {
+            required: true,
+            pattern: isodate_regex,
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.dateReviewed && "Date Reviewed is required. "}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="comments">Comments</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-comments"}
+          id="comments"
+          type="text"
+          isInvalid={Boolean(errors.description)}
+          {...register("comments", {
+            required: "Comments is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.comments?.message}
         </Form.Control.Feedback>
       </Form.Group>
 

--- a/frontend/src/main/components/MenuItemReviews/MenuItemReviewTable.js
+++ b/frontend/src/main/components/MenuItemReviews/MenuItemReviewTable.js
@@ -1,0 +1,75 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import {
+    cellToAxiosParamsDelete,
+    onDeleteSuccess,
+} from "main/utils/menuItemReviewUtils";
+import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export default function MenuItemReviewTable({
+    menuItemReviews,
+    currentUser,
+    testIdPrefix = "MenuItemReviewTable",
+}) {
+    const navigate = useNavigate();
+
+    const editCallback = (cell) => {
+        navigate(`/MenuItemReviews/edit/${cell.row.values.id}`);
+    };
+
+    // Stryker disable all : hard to test for query caching
+
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/MenuItemReviews/all"],
+    );
+    // Stryker restore all
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => {
+        deleteMutation.mutate(cell);
+    };
+
+    const columns = [
+        {
+            Header: "id",
+            accessor: "id", // accessor is the "key" in the data
+        },
+
+        {
+            Header: "ItemId",
+            accessor: "itemId",
+        },
+        {
+            Header: "Reviewer Email",
+            accessor: "reviewerEmail",
+        },
+        {
+            Header: "Stars",
+            accessor: "stars",
+        },
+        {
+            Header: "Date Reviewed",
+            accessor: "dateReviewed",
+        },
+        {
+            Header: "Comments",
+            accessor: "comments",
+        },
+    ];
+
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+        columns.push(
+            ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
+        );
+    }
+
+    return (
+        <OurTable data={menuItemReviews} columns={columns} testid={testIdPrefix} />
+    );
+}

--- a/frontend/src/main/components/MenuItemReviews/MenuItemReviewTable.js
+++ b/frontend/src/main/components/MenuItemReviews/MenuItemReviewTable.js
@@ -3,73 +3,73 @@ import OurTable, { ButtonColumn } from "main/components/OurTable";
 
 import { useBackendMutation } from "main/utils/useBackend";
 import {
-    cellToAxiosParamsDelete,
-    onDeleteSuccess,
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
 } from "main/utils/menuItemReviewUtils";
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 
 export default function MenuItemReviewTable({
-    menuItemReviews,
-    currentUser,
-    testIdPrefix = "MenuItemReviewTable",
+  menuItemReviews,
+  currentUser,
+  testIdPrefix = "MenuItemReviewTable",
 }) {
-    const navigate = useNavigate();
+  const navigate = useNavigate();
 
-    const editCallback = (cell) => {
-        navigate(`/MenuItemReviews/edit/${cell.row.values.id}`);
-    };
+  const editCallback = (cell) => {
+    navigate(`/MenuItemReviews/edit/${cell.row.values.id}`);
+  };
 
-    // Stryker disable all : hard to test for query caching
+  // Stryker disable all : hard to test for query caching
 
-    const deleteMutation = useBackendMutation(
-        cellToAxiosParamsDelete,
-        { onSuccess: onDeleteSuccess },
-        ["/api/MenuItemReviews/all"],
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/MenuItemReviews/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      Header: "id",
+      accessor: "id", // accessor is the "key" in the data
+    },
+
+    {
+      Header: "ItemId",
+      accessor: "itemId",
+    },
+    {
+      Header: "Reviewer Email",
+      accessor: "reviewerEmail",
+    },
+    {
+      Header: "Stars",
+      accessor: "stars",
+    },
+    {
+      Header: "Date Reviewed",
+      accessor: "dateReviewed",
+    },
+    {
+      Header: "Comments",
+      accessor: "comments",
+    },
+  ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
     );
-    // Stryker restore all
+  }
 
-    // Stryker disable next-line all : TODO try to make a good test for this
-    const deleteCallback = async (cell) => {
-        deleteMutation.mutate(cell);
-    };
-
-    const columns = [
-        {
-            Header: "id",
-            accessor: "id", // accessor is the "key" in the data
-        },
-
-        {
-            Header: "ItemId",
-            accessor: "itemId",
-        },
-        {
-            Header: "Reviewer Email",
-            accessor: "reviewerEmail",
-        },
-        {
-            Header: "Stars",
-            accessor: "stars",
-        },
-        {
-            Header: "Date Reviewed",
-            accessor: "dateReviewed",
-        },
-        {
-            Header: "Comments",
-            accessor: "comments",
-        },
-    ];
-
-    if (hasRole(currentUser, "ROLE_ADMIN")) {
-        columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
-        columns.push(
-            ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
-        );
-    }
-
-    return (
-        <OurTable data={menuItemReviews} columns={columns} testid={testIdPrefix} />
-    );
+  return (
+    <OurTable data={menuItemReviews} columns={columns} testid={testIdPrefix} />
+  );
 }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -69,6 +69,9 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/placeholder">
                     Placeholder
                   </Nav.Link>
+                  <Nav.Link as={Link} to="/MenuItemReviews">
+                    Menu Item Reviews
+                  </Nav.Link>
                 </>
               ) : (
                 <></>

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewCreatePage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
@@ -1,11 +1,50 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { Navigate } from "react-router-dom";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+import MenuItemReviewForm from "main/components/MenuItemReviews/MenuItemReviewForm";
 
-export default function MenuItemReviewCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function MenuItemReviewCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (menuItemReview) => ({
+    url: "/api/MenuItemReviews/post",
+    method: "POST",
+    params: {
+      itemId: menuItemReview.itemId,
+      reviewerEmail: menuItemReview.reviewerEmail,
+      stars: menuItemReview.stars,
+      dateReviewed: menuItemReview.dateReviewed,
+      comments: menuItemReview.comments
+    },
+  });
+
+  const onSuccess = (menuItemReview) => {
+    toast(
+      `New MenuItemReview Created - id: ${menuItemReview.id} name: ${menuItemReview.itemId}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/MenuItemReviews/all"], // mutation makes this key stale so that pages relying on it reload
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/MenuItemReviews" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New MenuItemReview</h1>
+        <MenuItemReviewForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
@@ -13,13 +13,13 @@ export default function MenuItemReviewCreatePage({ storybook = false }) {
       reviewerEmail: menuItemReview.reviewerEmail,
       stars: menuItemReview.stars,
       dateReviewed: menuItemReview.dateReviewed,
-      comments: menuItemReview.comments
+      comments: menuItemReview.comments,
     },
   });
 
   const onSuccess = (menuItemReview) => {
     toast(
-      `New MenuItemReview Created - id: ${menuItemReview.id} name: ${menuItemReview.itemId}`,
+      `New MenuItemReview Created - id: ${menuItemReview.id} itemId: ${menuItemReview.itemId}`,
     );
   };
 

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewEditPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
@@ -1,11 +1,79 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import { Navigate } from "react-router-dom";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+import MenuItemReviewForm from "main/components/MenuItemReviews/MenuItemReviewForm";
 
-export default function MenuItemReviewEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function MenuItemReviewEditPage({ storybook = false }) {
+  let { id } = useParams();
+
+  const {
+    data: MenuItemReview,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/MenuItemReviews?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/MenuItemReviews`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (menuItemReview) => ({
+    url: "/api/MenuItemReviews",
+    method: "PUT",
+    params: {
+      id: menuItemReview.id,
+    },
+    data: {
+      itemId: menuItemReview.itemId,
+      reviewerEmail: menuItemReview.reviewerEmail,
+      stars: menuItemReview.stars,
+      dateReviewed: menuItemReview.dateReviewed,
+      comments: menuItemReview.comments,
+    },
+  });
+
+  const onSuccess = (menuItemReview) => {
+    toast(
+      `MenuItemReview Updated - id: ${menuItemReview.id} itemId: ${menuItemReview.itemId}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/MenuItemReviews?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/MenuItemReviews" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit MenuItemReview</h1>
+        {MenuItemReview && (
+          <MenuItemReviewForm
+            submitAction={onSubmit}
+            buttonLabel={"Update"}
+            initialContents={MenuItemReview}
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
@@ -1,17 +1,49 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useCurrentUser, hasRole } from "main/utils/currentUser";
+import { Button } from "react-bootstrap";
+import MenuItemReviewTable from "main/components/MenuItemReviews/MenuItemReviewTable";
 
 export default function MenuItemReviewIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const {
+    data: menuItemReviews,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/MenuItemReviews/all"],
+    { method: "GET", url: "/api/MenuItemReviews/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/MenuItemReviews/create"
+          style={{ float: "right" }}
+        >
+          Create MenuItemReview
+        </Button>
+      );
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/MenuItemReviews/create">Create</a>
-        </p>
-        <p>
-          <a href="/MenuItemReviews/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>Menu Item Reviews</h1>
+        <MenuItemReviewTable
+          menuItemReviews={menuItemReviews}
+          currentUser={currentUser}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
@@ -1,0 +1,18 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewIndexPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p>
+          <a href="/MenuItemReviews/create">Create</a>
+        </p>
+        <p>
+          <a href="/MenuItemReviews/edit/1">Edit</a>
+        </p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/utils/menuItemReviewUtils.js
+++ b/frontend/src/main/utils/menuItemReviewUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/MenuItemReviews",
+    method: "DELETE",
+    params: {
+      id: cell.row.values.id,
+    },
+  };
+}

--- a/frontend/src/stories/components/MenuItemReviews/MenuItemReviewForm.stories.js
+++ b/frontend/src/stories/components/MenuItemReviews/MenuItemReviewForm.stories.js
@@ -1,0 +1,33 @@
+import React from "react";
+import MenuItemReviewForm from "main/components/MenuItemReviews/MenuItemReviewForm";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+
+export default {
+  title: "components/MenuItemReviews/MenuItemReviewForm",
+  component: MenuItemReviewForm,
+};
+
+const Template = (args) => {
+  return <MenuItemReviewForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: menuItemReviewFixtures.oneMenuItemReview,
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/stories/components/MenuItemReviews/MenuItemReviewTable.stories.js
+++ b/frontend/src/stories/components/MenuItemReviews/MenuItemReviewTable.stories.js
@@ -1,0 +1,45 @@
+import React from "react";
+import MenuItemReviewTable from "main/components/MenuItemReviews/MenuItemReviewTable";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/MenuItemReviews/MenuItemReviewTable",
+  component: MenuItemReviewTable,
+};
+
+const Template = (args) => {
+  return <MenuItemReviewTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  menuItemReviews: [],
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+  menuItemReviews: menuItemReviewFixtures.threeMenuItemReviews,
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+  menuItemReviews: menuItemReviewFixtures.threeMenuItemReviews,
+  currentUser: currentUserFixtures.adminUser,
+};
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.delete("/api/MenuItemReviews", () => {
+      return HttpResponse.json(
+        { message: "MenuItemReview deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewCreatePage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewCreatePage.stories.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+
+export default {
+  title: "pages/Restaurants/MenuItemReviewCreatePage",
+  component: MenuItemReviewCreatePage,
+};
+
+const Template = () => <MenuItemReviewCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/MenuItemReviews/post", () => {
+      return HttpResponse.json(menuItemReviewFixtures.oneMenuItemReview, {
+        status: 200,
+      });
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewIndexPage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewIndexPage.stories.js
@@ -1,0 +1,71 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+
+export default {
+  title: "pages/MenuItemReviews/MenuItemReviewIndexPage",
+  component: MenuItemReviewIndexPage,
+};
+
+const Template = () => <MenuItemReviewIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/MenuItemReviews/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/MenuItemReviews/all", () => {
+      return HttpResponse.json(menuItemReviewFixtures.threeMenuItemReviews);
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/MenuItemReviews/all", () => {
+      return HttpResponse.json(menuItemReviewFixtures.threeMenuItemReviews);
+    }),
+    http.delete("/api/MenuItemReviews", () => {
+      return HttpResponse.json(
+        { message: "MenuItemReview deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/MenuItemReviews/MenuItemReviewForm.test.js
+++ b/frontend/src/tests/components/MenuItemReviews/MenuItemReviewForm.test.js
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+
+import MenuItemReviewForm from "main/components/MenuItemReviews/MenuItemReviewForm";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe("MenuItemReviewForm tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "ItemId",
+    "Reviewer Email",
+    "Stars",
+    "Date Reviewed (iso format)",
+    "Comments",
+  ];
+  const testId = "MenuItemReviewForm";
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm
+            initialContents={menuItemReviewFixtures.oneMenuItemReview}
+          />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+    expect(screen.getByText(`Id`)).toBeInTheDocument();
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByText(/Create/);
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/ItemId is required./);
+    expect(screen.getByText(/ReviewerEmail is required./)).toBeInTheDocument();
+    expect(screen.getByText(/Stars is required./)).toBeInTheDocument();
+    expect(screen.getByText(/Date Reviewed is required./)).toBeInTheDocument();
+    expect(screen.getByText(/Comments is required./)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/MenuItemReviews/MenuItemReviewTable.test.js
+++ b/frontend/src/tests/components/MenuItemReviews/MenuItemReviewTable.test.js
@@ -21,6 +21,7 @@ describe("MenuItemReviewTable tests", () => {
   const queryClient = new QueryClient();
 
   const expectedHeaders = [
+    "id",
     "ItemId",
     "Reviewer Email",
     "Stars",

--- a/frontend/src/tests/components/MenuItemReviews/MenuItemReviewTable.test.js
+++ b/frontend/src/tests/components/MenuItemReviews/MenuItemReviewTable.test.js
@@ -179,12 +179,12 @@ describe("MenuItemReviewTable tests", () => {
     );
 
     // assert - check that the expected content is rendered
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
-      "2",
-    );
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
-    ).toHaveTextContent(1);
+        await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent(2);
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
+      ).toHaveTextContent(1);
 
     const editButton = screen.getByTestId(
       `${testId}-cell-row-0-col-Edit-button`,
@@ -222,12 +222,12 @@ describe("MenuItemReviewTable tests", () => {
     );
 
     // assert - check that the expected content is rendered
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
-      "2",
-    );
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
-    ).toHaveTextContent(1);
+        await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent(2);
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
+      ).toHaveTextContent(1);
 
     const deleteButton = screen.getByTestId(
       `${testId}-cell-row-0-col-Delete-button`,

--- a/frontend/src/tests/components/MenuItemReviews/MenuItemReviewTable.test.js
+++ b/frontend/src/tests/components/MenuItemReviews/MenuItemReviewTable.test.js
@@ -181,11 +181,11 @@ describe("MenuItemReviewTable tests", () => {
 
     // assert - check that the expected content is rendered
     expect(
-        await screen.findByTestId(`${testId}-cell-row-0-col-id`),
-      ).toHaveTextContent(2);
-      expect(
-        screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
-      ).toHaveTextContent(1);
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent(2);
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
+    ).toHaveTextContent(1);
 
     const editButton = screen.getByTestId(
       `${testId}-cell-row-0-col-Edit-button`,
@@ -224,11 +224,11 @@ describe("MenuItemReviewTable tests", () => {
 
     // assert - check that the expected content is rendered
     expect(
-        await screen.findByTestId(`${testId}-cell-row-0-col-id`),
-      ).toHaveTextContent(2);
-      expect(
-        screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
-      ).toHaveTextContent(1);
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent(2);
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
+    ).toHaveTextContent(1);
 
     const deleteButton = screen.getByTestId(
       `${testId}-cell-row-0-col-Delete-button`,

--- a/frontend/src/tests/components/MenuItemReviews/MenuItemReviewTable.test.js
+++ b/frontend/src/tests/components/MenuItemReviews/MenuItemReviewTable.test.js
@@ -1,5 +1,8 @@
 import { fireEvent, render, waitFor, screen } from "@testing-library/react";
-import { _menuItemReviewFixtures, menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import {
+  _menuItemReviewFixtures,
+  menuItemReviewFixtures,
+} from "fixtures/menuItemReviewFixtures";
 import MenuItemReviewTable from "main/components/MenuItemReviews/MenuItemReviewTable";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -10,227 +13,233 @@ import AxiosMockAdapter from "axios-mock-adapter";
 const mockedNavigate = jest.fn();
 
 jest.mock("react-router-dom", () => ({
-    ...jest.requireActual("react-router-dom"),
-    useNavigate: () => mockedNavigate,
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
 }));
 
 describe("MenuItemReviewTable tests", () => {
-    const queryClient = new QueryClient();
+  const queryClient = new QueryClient();
 
-    const expectedHeaders = [
-        "ItemId",
-        "Reviewer Email",
-        "Stars",
-        "Date Reviewed",
-        "Comments",
-    ];
-    const expectedFields = ["id", "reviewerEmail", "stars", "dateReviewed", "comments"];
-    const testId = "MenuItemReviewTable";
+  const expectedHeaders = [
+    "ItemId",
+    "Reviewer Email",
+    "Stars",
+    "Date Reviewed",
+    "Comments",
+  ];
+  const expectedFields = [
+    "id",
+    "reviewerEmail",
+    "stars",
+    "dateReviewed",
+    "comments",
+  ];
+  const testId = "MenuItemReviewTable";
 
-    test("renders empty table correctly", () => {
-        // arrange
-        const currentUser = currentUserFixtures.adminUser;
+  test("renders empty table correctly", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
 
-        // act
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <MenuItemReviewTable menuItemReviews={[]} currentUser={currentUser} />
-                </MemoryRouter>
-            </QueryClientProvider>,
-        );
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable menuItemReviews={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
 
-        // assert
-        expectedHeaders.forEach((headerText) => {
-            const header = screen.getByText(headerText);
-            expect(header).toBeInTheDocument();
-        });
-
-        expectedFields.forEach((field) => {
-            const fieldElement = screen.queryByTestId(
-                `${testId}-cell-row-0-col-${field}`,
-            );
-            expect(fieldElement).not.toBeInTheDocument();
-        });
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
     });
 
-    test("Has the expected column headers, content and buttons for admin user", () => {
-        // arrange
-        const currentUser = currentUserFixtures.adminUser;
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(
+        `${testId}-cell-row-0-col-${field}`,
+      );
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
 
-        // act
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <MenuItemReviewTable
-                        menuItemReviews={menuItemReviewFixtures.threeMenuItemReviews}
-                        currentUser={currentUser}
-                    />
-                </MemoryRouter>
-            </QueryClientProvider>,
-        );
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
 
-        // assert
-        expectedHeaders.forEach((headerText) => {
-            const header = screen.getByText(headerText);
-            expect(header).toBeInTheDocument();
-        });
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable
+            menuItemReviews={menuItemReviewFixtures.threeMenuItemReviews}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
 
-        expectedFields.forEach((field) => {
-            const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
-            expect(header).toBeInTheDocument();
-        });
-
-        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
-            "2",
-        );
-        expect(
-            screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
-        ).toHaveTextContent(1);
-
-        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
-            "3",
-        );
-        expect(
-            screen.getByTestId(`${testId}-cell-row-1-col-itemId`),
-        ).toHaveTextContent(2);
-
-        const editButton = screen.getByTestId(
-            `${testId}-cell-row-0-col-Edit-button`,
-        );
-        expect(editButton).toBeInTheDocument();
-        expect(editButton).toHaveClass("btn-primary");
-
-        const deleteButton = screen.getByTestId(
-            `${testId}-cell-row-0-col-Delete-button`,
-        );
-        expect(deleteButton).toBeInTheDocument();
-        expect(deleteButton).toHaveClass("btn-danger");
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
     });
 
-    test("Has the expected column headers, content for ordinary user", () => {
-        // arrange
-        const currentUser = currentUserFixtures.userOnly;
-
-        // act
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <MenuItemReviewTable
-                        menuItemReviews={menuItemReviewFixtures.threeMenuItemReviews}
-                        currentUser={currentUser}
-                    />
-                </MemoryRouter>
-            </QueryClientProvider>,
-        );
-
-        // assert
-        expectedHeaders.forEach((headerText) => {
-            const header = screen.getByText(headerText);
-            expect(header).toBeInTheDocument();
-        });
-
-        expectedFields.forEach((field) => {
-            const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
-            expect(header).toBeInTheDocument();
-        });
-
-        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
-            "2",
-        );
-        expect(
-            screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
-        ).toHaveTextContent(1);
-
-        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
-            "3",
-        );
-        expect(
-            screen.getByTestId(`${testId}-cell-row-1-col-itemId`),
-        ).toHaveTextContent(2);
-
-        expect(screen.queryByText("Delete")).not.toBeInTheDocument();
-        expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
     });
 
-    test("Edit button navigates to the edit page", async () => {
-        // arrange
-        const currentUser = currentUserFixtures.adminUser;
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
+    ).toHaveTextContent(1);
 
-        // act - render the component
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <MenuItemReviewTable
-                        menuItemReviews={menuItemReviewFixtures.threeMenuItemReviews}
-                        currentUser={currentUser}
-                    />
-                </MemoryRouter>
-            </QueryClientProvider>,
-        );
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "3",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-itemId`),
+    ).toHaveTextContent(2);
 
-        // assert - check that the expected content is rendered
-        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
-            "2",
-        );
-        expect(
-            screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
-        ).toHaveTextContent(1);
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
 
-        const editButton = screen.getByTestId(
-            `${testId}-cell-row-0-col-Edit-button`,
-        );
-        expect(editButton).toBeInTheDocument();
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
 
-        // act - click the edit button
-        fireEvent.click(editButton);
+  test("Has the expected column headers, content for ordinary user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.userOnly;
 
-        // assert - check that the navigate function was called with the expected path
-        await waitFor(() =>
-            expect(mockedNavigate).toHaveBeenCalledWith("/MenuItemReviews/edit/2"),
-        );
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable
+            menuItemReviews={menuItemReviewFixtures.threeMenuItemReviews}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
     });
 
-    test("Delete button calls delete callback", async () => {
-        // arrange
-        const currentUser = currentUserFixtures.adminUser;
-
-        const axiosMock = new AxiosMockAdapter(axios);
-        axiosMock
-            .onDelete("/api/MenuItemReviews")
-            .reply(200, { message: "MenuItemReview deleted" });
-
-        // act - render the component
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <MenuItemReviewTable
-                        menuItemReviews={menuItemReviewFixtures.threeMenuItemReviews}
-                        currentUser={currentUser}
-                    />
-                </MemoryRouter>
-            </QueryClientProvider>,
-        );
-
-        // assert - check that the expected content is rendered
-        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
-            "2",
-        );
-        expect(
-            screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
-        ).toHaveTextContent(1);
-
-        const deleteButton = screen.getByTestId(
-            `${testId}-cell-row-0-col-Delete-button`,
-        );
-        expect(deleteButton).toBeInTheDocument();
-
-        // act - click the delete button
-        fireEvent.click(deleteButton);
-
-        // assert - check that the delete endpoint was called
-
-        await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
-        expect(axiosMock.history.delete[0].params).toEqual({ id: 2 });
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
     });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
+    ).toHaveTextContent(1);
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "3",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-itemId`),
+    ).toHaveTextContent(2);
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+  test("Edit button navigates to the edit page", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable
+            menuItemReviews={menuItemReviewFixtures.threeMenuItemReviews}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert - check that the expected content is rendered
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
+    ).toHaveTextContent(1);
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+
+    // act - click the edit button
+    fireEvent.click(editButton);
+
+    // assert - check that the navigate function was called with the expected path
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith("/MenuItemReviews/edit/2"),
+    );
+  });
+
+  test("Delete button calls delete callback", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock
+      .onDelete("/api/MenuItemReviews")
+      .reply(200, { message: "MenuItemReview deleted" });
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable
+            menuItemReviews={menuItemReviewFixtures.threeMenuItemReviews}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert - check that the expected content is rendered
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
+    ).toHaveTextContent(1);
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    // act - click the delete button
+    fireEvent.click(deleteButton);
+
+    // assert - check that the delete endpoint was called
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 2 });
+  });
 });

--- a/frontend/src/tests/components/MenuItemReviews/MenuItemReviewTable.test.js
+++ b/frontend/src/tests/components/MenuItemReviews/MenuItemReviewTable.test.js
@@ -1,0 +1,236 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { _menuItemReviewFixtures, menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import MenuItemReviewTable from "main/components/MenuItemReviews/MenuItemReviewTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+    ...jest.requireActual("react-router-dom"),
+    useNavigate: () => mockedNavigate,
+}));
+
+describe("MenuItemReviewTable tests", () => {
+    const queryClient = new QueryClient();
+
+    const expectedHeaders = [
+        "ItemId",
+        "Reviewer Email",
+        "Stars",
+        "Date Reviewed",
+        "Comments",
+    ];
+    const expectedFields = ["id", "reviewerEmail", "stars", "dateReviewed", "comments"];
+    const testId = "MenuItemReviewTable";
+
+    test("renders empty table correctly", () => {
+        // arrange
+        const currentUser = currentUserFixtures.adminUser;
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewTable menuItemReviews={[]} currentUser={currentUser} />
+                </MemoryRouter>
+            </QueryClientProvider>,
+        );
+
+        // assert
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+        expectedFields.forEach((field) => {
+            const fieldElement = screen.queryByTestId(
+                `${testId}-cell-row-0-col-${field}`,
+            );
+            expect(fieldElement).not.toBeInTheDocument();
+        });
+    });
+
+    test("Has the expected column headers, content and buttons for admin user", () => {
+        // arrange
+        const currentUser = currentUserFixtures.adminUser;
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewTable
+                        menuItemReviews={menuItemReviewFixtures.threeMenuItemReviews}
+                        currentUser={currentUser}
+                    />
+                </MemoryRouter>
+            </QueryClientProvider>,
+        );
+
+        // assert
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+        expectedFields.forEach((field) => {
+            const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+            expect(header).toBeInTheDocument();
+        });
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+            "2",
+        );
+        expect(
+            screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
+        ).toHaveTextContent(1);
+
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+            "3",
+        );
+        expect(
+            screen.getByTestId(`${testId}-cell-row-1-col-itemId`),
+        ).toHaveTextContent(2);
+
+        const editButton = screen.getByTestId(
+            `${testId}-cell-row-0-col-Edit-button`,
+        );
+        expect(editButton).toBeInTheDocument();
+        expect(editButton).toHaveClass("btn-primary");
+
+        const deleteButton = screen.getByTestId(
+            `${testId}-cell-row-0-col-Delete-button`,
+        );
+        expect(deleteButton).toBeInTheDocument();
+        expect(deleteButton).toHaveClass("btn-danger");
+    });
+
+    test("Has the expected column headers, content for ordinary user", () => {
+        // arrange
+        const currentUser = currentUserFixtures.userOnly;
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewTable
+                        menuItemReviews={menuItemReviewFixtures.threeMenuItemReviews}
+                        currentUser={currentUser}
+                    />
+                </MemoryRouter>
+            </QueryClientProvider>,
+        );
+
+        // assert
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+        expectedFields.forEach((field) => {
+            const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+            expect(header).toBeInTheDocument();
+        });
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+            "2",
+        );
+        expect(
+            screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
+        ).toHaveTextContent(1);
+
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+            "3",
+        );
+        expect(
+            screen.getByTestId(`${testId}-cell-row-1-col-itemId`),
+        ).toHaveTextContent(2);
+
+        expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+        expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+    });
+
+    test("Edit button navigates to the edit page", async () => {
+        // arrange
+        const currentUser = currentUserFixtures.adminUser;
+
+        // act - render the component
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewTable
+                        menuItemReviews={menuItemReviewFixtures.threeMenuItemReviews}
+                        currentUser={currentUser}
+                    />
+                </MemoryRouter>
+            </QueryClientProvider>,
+        );
+
+        // assert - check that the expected content is rendered
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+            "2",
+        );
+        expect(
+            screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
+        ).toHaveTextContent(1);
+
+        const editButton = screen.getByTestId(
+            `${testId}-cell-row-0-col-Edit-button`,
+        );
+        expect(editButton).toBeInTheDocument();
+
+        // act - click the edit button
+        fireEvent.click(editButton);
+
+        // assert - check that the navigate function was called with the expected path
+        await waitFor(() =>
+            expect(mockedNavigate).toHaveBeenCalledWith("/MenuItemReviews/edit/2"),
+        );
+    });
+
+    test("Delete button calls delete callback", async () => {
+        // arrange
+        const currentUser = currentUserFixtures.adminUser;
+
+        const axiosMock = new AxiosMockAdapter(axios);
+        axiosMock
+            .onDelete("/api/MenuItemReviews")
+            .reply(200, { message: "MenuItemReview deleted" });
+
+        // act - render the component
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewTable
+                        menuItemReviews={menuItemReviewFixtures.threeMenuItemReviews}
+                        currentUser={currentUser}
+                    />
+                </MemoryRouter>
+            </QueryClientProvider>,
+        );
+
+        // assert - check that the expected content is rendered
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+            "2",
+        );
+        expect(
+            screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
+        ).toHaveTextContent(1);
+
+        const deleteButton = screen.getByTestId(
+            `${testId}-cell-row-0-col-Delete-button`,
+        );
+        expect(deleteButton).toBeInTheDocument();
+
+        // act - click the delete button
+        fireEvent.click(deleteButton);
+
+        // assert - check that the delete endpoint was called
+
+        await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+        expect(axiosMock.history.delete[0].params).toEqual({ id: 2 });
+    });
+});

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
@@ -7,7 +7,6 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
 
 describe("MenuItemReviewCreate tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
@@ -1,17 +1,42 @@
-import { render, screen } from "@testing-library/react";
-import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
 
-describe("MenuItemReviewCreate tests", () => {
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
+
+describe("MenuItemReviewCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -20,15 +45,10 @@ describe("MenuItemReviewCreate tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
+  test("renders without crashing", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -37,8 +57,81 @@ describe("MenuItemReviewCreate tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
+    await waitFor(() => {
+      expect(screen.getByLabelText("ItemId")).toBeInTheDocument();
+    });
+  });
 
-    await screen.findByText("Create page not yet implemented");
+  test("on submit, makes request to backend, and redirects to /MenuItemReviews", async () => {
+    const queryClient = new QueryClient();
+    const menuItemReview = {
+      id: 3,
+      itemId: 2,
+      reviewerEmail: "tyler_wong@ucsb.edu",
+      stars: 4,
+      dateReviewed: "2025-04-26T03:15:29.774",
+      comments: "Quite good.",
+    };
+
+    axiosMock.onPost("/api/MenuItemReviews/post").reply(202, menuItemReview);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("ItemId")).toBeInTheDocument();
+    });
+
+    const itemIdInput = screen.getByLabelText("ItemId");
+    expect(itemIdInput).toBeInTheDocument();
+
+    const reviewerEmailInput = screen.getByLabelText("Reviewer Email");
+    expect(reviewerEmailInput).toBeInTheDocument();
+
+    const starsInput = screen.getByLabelText("Stars");
+    expect(starsInput).toBeInTheDocument();
+
+    const dateReviewedInput = screen.getByLabelText(
+      "Date Reviewed (iso format)",
+    );
+    expect(dateReviewedInput).toBeInTheDocument();
+
+    const commentsInput = screen.getByLabelText("Comments");
+    expect(commentsInput).toBeInTheDocument();
+
+    const createButton = screen.getByText("Create");
+    expect(createButton).toBeInTheDocument();
+
+    fireEvent.change(itemIdInput, { target: { value: 2 } });
+    fireEvent.change(reviewerEmailInput, {
+      target: { value: "tyler_wong@ucsb.edu" },
+    });
+    fireEvent.change(starsInput, { target: { value: 4 } });
+    fireEvent.change(dateReviewedInput, {
+      target: { value: "2025-04-26T03:15:29.774" },
+    });
+    fireEvent.change(commentsInput, { target: { value: "Quite good." } });
+    fireEvent.click(createButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      itemId: "2",
+      reviewerEmail: "tyler_wong@ucsb.edu",
+      stars: "4",
+      dateReviewed: "2025-04-26T03:15:29.774",
+      comments: "Quite good.",
+    });
+
+    // assert - check that the toast was called with the expected message
+    expect(mockToast).toHaveBeenCalledWith(
+      "New MenuItemReview Created - id: 3 itemId: 2",
+    );
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/MenuItemReviews" });
   });
 });

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
+
+describe("MenuItemReviewCreate tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+
+    await screen.findByText("Create page not yet implemented");
+  });
+});

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("MenuItemReviewEditPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewEditPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await screen.findByText("Edit page not yet implemented");
+  });
+});

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
@@ -1,5 +1,4 @@
-import { render, screen } from "@testing-library/react";
-import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
@@ -7,37 +6,182 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useParams: () => ({
+      id: 17,
+    }),
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
 
 describe("MenuItemReviewEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
+  describe("when the backend doesn't return data", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
-  };
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/MenuItemReviews", { params: { id: 17 } }).timeout();
+    });
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
+    const queryClient = new QueryClient();
+    test("renders header but table is not present", async () => {
+      const restoreConsole = mockConsole();
 
-    setupUserOnly();
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <MenuItemReviewEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit MenuItemReview");
+      expect(
+        screen.queryByTestId("MenuItemReview-itemId"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
 
-    // act
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <MenuItemReviewEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+  describe("tests where backend is working normally", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
-    // assert
-    await screen.findByText("Edit page not yet implemented");
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/MenuItemReviews", { params: { id: 17 } })
+        .reply(200, {
+          id: 17,
+          itemId: 10,
+          reviewerEmail: "tyguywong@gmail.com",
+          stars: 1,
+          dateReviewed: "2025-04-26T04:18:01.047",
+          comments: "Very good.",
+        });
+      axiosMock.onPut("/api/MenuItemReviews").reply(200, {
+        id: 17,
+        itemId: 9,
+        reviewerEmail: "tyguyw0ng@gmail.com",
+        stars: 2,
+        dateReviewed: "2025-04-26T04:18:01.045",
+        comments: "Very bad.",
+      });
+    });
+
+    const queryClient = new QueryClient();
+
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <MenuItemReviewEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("MenuItemReviewForm-id");
+
+      const idField = screen.getByTestId("MenuItemReviewForm-id");
+      const itemIdField = screen.getByLabelText("ItemId");
+      const reviewerEmailField = screen.getByLabelText("Reviewer Email");
+      const starsField = screen.getByLabelText("Stars");
+      const dateReviewedField = screen.getByLabelText(
+        "Date Reviewed (iso format)",
+      );
+      const commentsField = screen.getByLabelText("Comments");
+      const submitButton = screen.getByText("Update");
+
+      expect(idField).toBeInTheDocument();
+      expect(idField).toHaveValue("17");
+
+      expect(itemIdField).toBeInTheDocument();
+      expect(itemIdField).toHaveValue(10);
+
+      expect(reviewerEmailField).toBeInTheDocument();
+      expect(reviewerEmailField).toHaveValue("tyguywong@gmail.com");
+
+      expect(starsField).toBeInTheDocument();
+      expect(starsField).toHaveValue(1);
+
+      expect(dateReviewedField).toBeInTheDocument();
+      expect(dateReviewedField).toHaveValue("2025-04-26T04:18:01.047");
+
+      expect(commentsField).toBeInTheDocument();
+      expect(commentsField).toHaveValue("Very good.");
+
+      expect(submitButton).toHaveTextContent("Update");
+
+      fireEvent.change(itemIdField, {
+        target: { value: "9" },
+      });
+      fireEvent.change(reviewerEmailField, {
+        target: { value: "tyguyw0ng@gmail.com" },
+      });
+      fireEvent.change(starsField, {
+        target: { value: "2" },
+      });
+      fireEvent.change(dateReviewedField, {
+        target: { value: "2025-04-26T04:18:01.045" },
+      });
+      fireEvent.change(commentsField, {
+        target: { value: "Very bad." },
+      });
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toHaveBeenCalled());
+      expect(mockToast).toHaveBeenCalledWith(
+        "MenuItemReview Updated - id: 17 itemId: 9",
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith({ to: "/MenuItemReviews" });
+
+      expect(axiosMock.history.put.length).toBe(1); // times called
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          itemId: "9",
+          reviewerEmail: "tyguyw0ng@gmail.com",
+          stars: "2",
+          dateReviewed: "2025-04-26T04:18:01.045",
+          comments: "Very bad.",
+        }),
+      ); // posted object
+      expect(mockNavigate).toHaveBeenCalledWith({ to: "/MenuItemReviews" });
+    });
   });
 });

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
@@ -7,7 +7,6 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
 
 describe("MenuItemReviewIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+
+describe("MenuItemReviewIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Index page not yet implemented");
+
+    // assert
+    expect(
+      screen.getByText("Index page not yet implemented"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Create")).toBeInTheDocument();
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
@@ -1,15 +1,29 @@
-import { render, screen } from "@testing-library/react";
-import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import mockConsole from "jest-mock-console";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
 
 describe("MenuItemReviewIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "MenuItemReviewTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,13 +36,22 @@ describe("MenuItemReviewIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
 
-    setupUserOnly();
-
-    // act
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/MenuItemReviews/all").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -38,13 +61,143 @@ describe("MenuItemReviewIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    await waitFor(() => {
+      expect(screen.getByText(/Create MenuItemReview/)).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Create MenuItemReview/);
+    expect(button).toHaveAttribute("href", "/MenuItemReviews/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
 
-    // assert
+  test("renders three MenuItemReviews correctly for regular user", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/MenuItemReviews/all")
+      .reply(200, menuItemReviewFixtures.threeMenuItemReviews);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("2");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "3",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "4",
+    );
+
+    const createMenuItemReviewButton = screen.queryByText(
+      "Create MenuItemReview",
+    );
+    expect(createMenuItemReviewButton).not.toBeInTheDocument();
+
+    const itemId = screen.getByTestId(
+      "MenuItemReviewTable-cell-row-1-col-itemId",
+    );
+    expect(itemId).toHaveTextContent("2");
+
+    const reviewerEmail = screen.getByText("tyler_wong@ucsb.edu");
+    expect(reviewerEmail).toBeInTheDocument();
+
+    const stars = screen.getByTestId(
+      "MenuItemReviewTable-cell-row-0-col-stars",
+    );
+    expect(stars).toHaveTextContent("4");
+
+    const dateReviewed = screen.getByText("2025-04-26T04:18:01.047");
+    expect(dateReviewed).toBeInTheDocument();
+
+    const comments = screen.getByText("Quite good.");
+    expect(comments).toBeInTheDocument();
+
+    // for non-admin users, details button is visible, but the edit and delete buttons should not be visible
     expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
-    expect(screen.getByText("Edit")).toBeInTheDocument();
+      screen.queryByTestId("MenuItemReviewTable-cell-row-0-col-Delete-button"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("MenuItemReviewTable-cell-row-0-col-Edit-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+
+    axiosMock.onGet("/api/MenuItemReviews/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/MenuItemReviews/all",
+    );
+    restoreConsole();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+
+    axiosMock
+      .onGet("/api/MenuItemReviews/all")
+      .reply(200, menuItemReviewFixtures.threeMenuItemReviews);
+    axiosMock
+      .onDelete("/api/MenuItemReviews")
+      .reply(200, "MenuItemReview with id 1 was deleted");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "2",
+    );
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith("MenuItemReview with id 1 was deleted");
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe("/api/MenuItemReviews");
+    expect(axiosMock.history.delete[0].url).toBe("/api/MenuItemReviews");
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 2 });
   });
 });

--- a/frontend/src/tests/utils/menuItemReviewUtils.test.js
+++ b/frontend/src/tests/utils/menuItemReviewUtils.test.js
@@ -1,0 +1,51 @@
+import {
+  onDeleteSuccess,
+  cellToAxiosParamsDelete,
+} from "main/utils/menuItemReviewUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+describe("menuItemReviewUtils", () => {
+  describe("onDeleteSuccess", () => {
+    test("It puts the message on console.log and in a toast", () => {
+      // arrange
+      const restoreConsole = mockConsole();
+
+      // act
+      onDeleteSuccess("abc");
+
+      // assert
+      expect(mockToast).toHaveBeenCalledWith("abc");
+      expect(console.log).toHaveBeenCalled();
+      const message = console.log.mock.calls[0][0];
+      expect(message).toMatch("abc");
+
+      restoreConsole();
+    });
+  });
+  describe("cellToAxiosParamsDelete", () => {
+    test("It returns the correct params", () => {
+      // arrange
+      const cell = { row: { values: { id: 17 } } };
+
+      // act
+      const result = cellToAxiosParamsDelete(cell);
+
+      // assert
+      expect(result).toEqual({
+        url: "/api/MenuItemReviews",
+        method: "DELETE",
+        params: { id: 17 },
+      });
+    });
+  });
+});

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewsController.java
@@ -1,0 +1,161 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.MenuItemsReviewRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.eclipse.jetty.client.Request.CommitListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+
+/**
+ * This is a REST controller for MenuItemReviews
+ */
+
+@Tag(name = "MenuItemReviews")
+@RequestMapping("/api/MenuItemReviews")
+@RestController
+@Slf4j
+
+public class MenuItemReviewsController extends ApiController {
+
+    @Autowired
+    MenuItemsReviewRepository menuItemsReviewRepository;
+
+    /**
+     * List all MenuItemReviews
+     * 
+     * @return an iterable of MenuItemReviews
+     */
+    @Operation(summary = "List all menuitemreviews")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<MenuItemReview> allMenuItemReviews() {
+        Iterable<MenuItemReview> menuitemreviews = menuItemsReviewRepository.findAll();
+        return menuitemreviews;
+    }
+
+    /**
+     * Create a new date
+     * 
+     * @param itemId        id of item reviewed
+     * @param reviewerEmail email of reviewer
+     * @param stars         number of stars given for item
+     * @param dateReviewed  date item was reviewed
+     * @param comments      additional comments
+     * @return the saved MenuItemReview
+     */
+    @Operation(summary = "Create a new MenuItemReview")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public MenuItemReview postMenuItemReview(
+            @Parameter(name = "itemId") @RequestParam Long itemId,
+            @Parameter(name = "reviewerEmail") @RequestParam String reviewerEmail,
+            @Parameter(name = "stars") @RequestParam int stars,
+            @Parameter(name = "dateReviewed") @RequestParam("dateReviewed") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateReviewed,
+            @Parameter(name = "comments") @RequestParam String comments)
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("dateReviewed={}", dateReviewed);
+
+        MenuItemReview menuItemReview = new MenuItemReview();
+        menuItemReview.setItemId(itemId);
+        menuItemReview.setReviewerEmail(reviewerEmail);
+        menuItemReview.setStars(stars);
+        menuItemReview.setDateReviewed(dateReviewed);
+        menuItemReview.setComments(comments);
+
+        MenuItemReview savedMenuItemReview = menuItemsReviewRepository.save(menuItemReview);
+
+        return savedMenuItemReview;
+    }
+
+    /**
+     * Get a single menuitemreview by id
+     * 
+     * @param id the id of the menuitemreview
+     * @return a MenuItemReview
+     */
+    @Operation(summary= "Get a single menuitemreview")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public MenuItemReview getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        MenuItemReview menuItemReview = menuItemsReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        return menuItemReview;
+    }
+
+    /**
+     * Update a single meniuitemreview
+     * 
+     * @param id       id of the menuitemreview to update
+     * @param incoming the new menuitemreview
+     * @return the updated menuitemreview object
+     */
+    @Operation(summary= "Update a single menuitemreview")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public MenuItemReview updateMenuItemReview(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid MenuItemReview incoming) {
+
+        MenuItemReview menuItemReview = menuItemsReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        menuItemReview.setItemId(incoming.getItemId());
+        menuItemReview.setReviewerEmail(incoming.getReviewerEmail());
+        menuItemReview.setStars(incoming.getStars());
+        menuItemReview.setDateReviewed(incoming.getDateReviewed());
+        menuItemReview.setComments(incoming.getComments());
+
+        menuItemsReviewRepository.save(menuItemReview);
+
+        return menuItemReview;
+    }
+
+    /**
+     * Delete a MenuItemReview
+     * 
+     * @param id the id of the menuitemreview to delete
+     * @return a message indicating the menuitemreview was deleted
+     */
+    @Operation(summary= "Delete a MenuItemReview")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteMenuItemReview(
+            @Parameter(name="id") @RequestParam Long id) {
+        MenuItemReview menuItemReview = menuItemsReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        menuItemsReviewRepository.delete(menuItemReview);
+        return genericMessage("MenuItemReview with id %s deleted".formatted(id));
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewsController.java
@@ -29,7 +29,6 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 
 import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
 
 /**
  * This is a REST controller for MenuItemReviews

--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -1,0 +1,32 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/** 
+ * This is a JPA entity that represents a Menu Item Review
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "menuitemreviews")
+public class MenuItemReview {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  private Long itemId;
+  private String reviewerEmail;
+  private int stars;
+  private LocalDateTime dateReviewed;
+  private String comments;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemsReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemsReviewRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+
+import org.springframework.beans.propertyeditors.StringArrayPropertyEditor;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The UCSBDiningCommonsRepository is a repository for MenuItemReview entities
+ */
+@Repository
+public interface MenuItemsReviewRepository extends CrudRepository<MenuItemReview, Long> {
+ 
+}

--- a/src/main/resources/db/migration/changes/MenuItemReviews.json
+++ b/src/main/resources/db/migration/changes/MenuItemReviews.json
@@ -1,0 +1,81 @@
+{ "databaseChangeLog": [
+    {
+        "changeSet": {
+          "id": "MenuItemReviews-1",
+          "author": "Tyler-W0ng",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "MENUITEMREVIEWS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "MENUITEMREVIEWS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "ITEM_ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "REVIEWER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "STARS",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_REVIEWED",
+                      "type": "TIMESTAMP WITH TIME ZONE"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "COMMENTS",
+                      "type": "VARCHAR(255)"
+                    }
+                  }]
+                ,
+                "tableName": "MENUITEMREVIEWS"
+              }
+            }]
+
+        }
+    }
+]}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewsControllerTests.java
@@ -1,0 +1,325 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.repositories.MenuItemsReviewRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = MenuItemReviewsController.class)
+@Import(TestConfig.class)
+public class MenuItemReviewsControllerTests extends ControllerTestCase{
+    
+    @MockBean
+    MenuItemsReviewRepository menuItemsReviewRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/MenuItemReviews/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/MenuItemReviews/all"))
+                            .andExpect(status().is(200)); // logged
+    }
+
+    
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/MenuItemReviews/post"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/MenuItemReviews/post"))
+                            .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+
+                // arrange
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                MenuItemReview menuitemreview1 = MenuItemReview.builder()
+                    .itemId(Long.valueOf(1))
+                    .reviewerEmail("tyler_wong@ucsb.edu")
+                    .stars(4)
+                    .dateReviewed(ldt1)
+                    .comments("Quite good.")
+                    .build();
+
+                ArrayList<MenuItemReview> expectedMenuItemReviews = new ArrayList<>();
+                expectedMenuItemReviews.addAll(Arrays.asList(menuitemreview1));
+
+                when(menuItemsReviewRepository.findAll()).thenReturn(expectedMenuItemReviews);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/MenuItemReviews/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(menuItemsReviewRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedMenuItemReviews);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_menuitemreview() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                MenuItemReview menuitemreview1 = MenuItemReview.builder()
+                    .itemId(Long.valueOf(1))
+                    .reviewerEmail("tyler_wong@ucsb.edu")
+                    .stars(4)
+                    .dateReviewed(ldt1)
+                    .comments("Good.")
+                    .build();
+
+                when(menuItemsReviewRepository.save(eq(menuitemreview1))).thenReturn(menuitemreview1);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/MenuItemReviews/post?itemId=1&reviewerEmail=tyler_wong@ucsb.edu&stars=4&dateReviewed=2022-01-03T00:00:00&comments=Good.")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(menuItemsReviewRepository, times(1)).save(eq(menuitemreview1));
+                String expectedJson = mapper.writeValueAsString(menuitemreview1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/MenuItemReviews?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(menuItemsReviewRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/MenuItemReviews?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(menuItemsReviewRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("MenuItemReview with id 7 not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does() throws Exception {
+
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                MenuItemReview menuitemreview1 = MenuItemReview.builder()
+                    .itemId(Long.valueOf(1))
+                    .reviewerEmail("tyler_wong@ucsb.edu")
+                    .stars(4)
+                    .dateReviewed(ldt1)
+                    .comments("Good.")
+                    .build();
+
+                when(menuItemsReviewRepository.findById(eq(7L))).thenReturn(Optional.of(menuitemreview1));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/MenuItemReviews?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(menuItemsReviewRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(menuitemreview1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_menuitemreview() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+                LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+                MenuItemReview menuitemreview1 = MenuItemReview.builder()
+                        .itemId(Long.valueOf(1))
+                        .reviewerEmail("tyler_wong@ucsb.edu")
+                        .stars(4)
+                        .dateReviewed(ldt1)
+                        .comments("Good.")
+                        .build();
+
+                MenuItemReview editedMenuItemReview = MenuItemReview.builder()
+                        .itemId(Long.valueOf(2))
+                        .reviewerEmail("tyler_w0ng@ucsb.edu")
+                        .stars(3)
+                        .dateReviewed(ldt2)
+                        .comments("Ok")
+                        .build();
+
+                String requestBody = mapper.writeValueAsString(editedMenuItemReview);
+
+                when(menuItemsReviewRepository.findById(eq(67L))).thenReturn(Optional.of(menuitemreview1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/MenuItemReviews?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(menuItemsReviewRepository, times(1)).findById(67L);
+                verify(menuItemsReviewRepository, times(1)).save(editedMenuItemReview); 
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_menuitemreviews_that_does_not_exist() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                MenuItemReview editedMenuItemReview = MenuItemReview.builder()
+                        .itemId(Long.valueOf(2))
+                        .reviewerEmail("tyler_w0ng@ucsb.edu")
+                        .stars(3)
+                        .dateReviewed(ldt1)
+                        .comments("Ok")
+                        .build();
+
+                String requestBody = mapper.writeValueAsString(editedMenuItemReview);
+
+                when(menuItemsReviewRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/MenuItemReviews?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(menuItemsReviewRepository, times(1)).findById(67L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("MenuItemReview with id 67 not found", json.get("message"));
+
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_menuitemreview() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                MenuItemReview menuitemreview1 = MenuItemReview.builder()
+                        .itemId(Long.valueOf(1))
+                        .reviewerEmail("tyler_wong@ucsb.edu")
+                        .stars(4)
+                        .dateReviewed(ldt1)
+                        .comments("Good.")
+                        .build();
+
+                when(menuItemsReviewRepository.findById(eq(15L))).thenReturn(Optional.of(menuitemreview1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/MenuItemReviews?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(menuItemsReviewRepository, times(1)).findById(15L);
+                verify(menuItemsReviewRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("MenuItemReview with id 15 deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_menuitemreview_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(menuItemsReviewRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/MenuItemReviews?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(menuItemsReviewRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("MenuItemReview with id 15 not found", json.get("message"));
+        }
+}


### PR DESCRIPTION
Closes #42 

In this PR, we replace the placeholder MenuItemReview edit page and replace it with a working edit page.

To test:

1. Visit the dokku deployment at https://team02-dev-tyler-w0ng.dokku-15.cs.ucsb.edu/
2. Login
3. Navigate to the MenuItemReview page. If there isn't a MenuItemReview listed there, create one.
4. Make changes to each of the fields and click Update
5. See that your changes took effect

