### PR TITLE
yc - add javascipt fixtures for UCSBOrganization table

### DIFF
--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -1,0 +1,31 @@
+const ucsbOrganizationFixtures = {
+    oneOrganization: {
+      "orgCode": "ZPR",
+      "orgTranslationShort": "ZETA PHI RHO",
+      "orgTranslation": "ZETA PHI RHO",
+      "inactive": false
+    },
+    threeOrganizations: [
+      {
+        "orgCode": "ZPR",
+        "orgTranslationShort": "ZETA PHI RHO",
+        "orgTranslation": "ZETA PHI RHO",
+        "inactive": false
+      },
+      {
+        "orgCode": "SKY",
+        "orgTranslationShort": "SKYDIVING CLUB",
+        "orgTranslation": "SKYDIVING CLUB AT UCSB",
+        "inactive": false
+      },
+      {
+        "orgCode": "OSLI",
+        "orgTranslationShort": "STUDENT LIFE",
+        "orgTranslation": "OFFICE OF STUDENT LIFE",
+        "inactive": false
+      }
+    ],
+  };
+  
+  export { ucsbOrganizationFixtures };
+  

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,0 +1,153 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a REST controller for UCSBOrganization
+ */
+
+@Tag(name = "UCSBOrganization")
+@RequestMapping("/api/ucsborganization")
+@RestController
+@Slf4j
+public class UCSBOrganizationController extends ApiController{
+
+    @Autowired
+    UCSBOrganizationRepository ucsbOrganizationRepository;
+
+    /**
+     * List all UCSB Organizations
+     * 
+     * @return an iterable of UCSBOrganization
+     */
+    @Operation(summary= "List all ucsb organizations")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBOrganization> allUCSBOrganization() {
+        Iterable<UCSBOrganization> organizations = ucsbOrganizationRepository.findAll();
+        return organizations;
+    }
+
+    /**
+     * Create a new organization
+     * 
+     * @param orgCode  the organization code
+     * @param orgTranslationShort  the short translation of the organization
+     * @param orgTranslation  the translation of the organization
+     * @param inactive  activity level of the organization
+     * @return the saved ucsborganization
+     */
+    @Operation(summary= "Create a new organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBOrganization postUCSBOrganization(
+            @Parameter(name="orgCode") @RequestParam String orgCode,
+            @Parameter(name="orgTranslationShort") @RequestParam String orgTranslationShort,
+            @Parameter(name="orgTranslation") @RequestParam String orgTranslation,
+            @Parameter(name="inactive") @RequestParam Boolean inactive
+            )
+            {
+
+            UCSBOrganization ucsbOrganization = new UCSBOrganization();
+            ucsbOrganization.setOrgCode(orgCode);
+            ucsbOrganization.setOrgTranslationShort(orgTranslationShort);
+            ucsbOrganization.setOrgTranslation(orgTranslation);
+            ucsbOrganization.setInactive(inactive);
+
+            UCSBOrganization savedUcsbOrganization = ucsbOrganizationRepository.save(ucsbOrganization);
+
+            return savedUcsbOrganization;
+            
+    }
+
+
+    /**
+     * Get a single UCSB organization by id
+     * 
+     * @param orgCode the id of the UCSB organization
+     * @return a UCSBDOrganization
+     */
+    @Operation(summary= "Get a single organization")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBOrganization getById(
+            @Parameter(name="orgCode") @RequestParam String orgCode) {
+        UCSBOrganization ucsbOrganization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        return ucsbOrganization;
+    }
+
+
+    /**
+     * Update a single organization
+     * 
+     * @param orgCode       id of the organization to update
+     * @param incoming the new organization
+     * @return the updated organization object
+     */
+    @Operation(summary= "Update a single organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBOrganization updateUCSBOrganization(
+            @Parameter(name="orgCode") @RequestParam String orgCode,
+            @RequestBody @Valid UCSBOrganization incoming) {
+
+        UCSBOrganization ucsbOrganization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        ucsbOrganization.setOrgTranslationShort(incoming.getOrgTranslationShort());
+        ucsbOrganization.setOrgTranslation(incoming.getOrgTranslation());
+        ucsbOrganization.setInactive(incoming.getInactive());
+
+        ucsbOrganizationRepository.save(ucsbOrganization);
+
+        return ucsbOrganization;
+    }
+
+
+    /**
+     * Delete a UCSBOrganization
+     * 
+     * @param orgCode the id of the organization to delete
+     * @return a message indicating the organization was deleted
+     */
+    @Operation(summary= "Delete a UCSBOrganization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteUCSBOrganization(
+            @Parameter(name="orgCode") @RequestParam String orgCode) {
+        UCSBOrganization ucsbOrganization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        ucsbOrganizationRepository.delete(ucsbOrganization);
+        return genericMessage("UCSBOrganization with id %s deleted".formatted(orgCode));
+    }
+
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
@@ -1,0 +1,30 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a JPA entity that represents a UCSBOrganization.
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsborganization")
+public class UCSBOrganization {
+  @Id
+  private String orgCode;
+
+  private String orgTranslationShort;
+  private String orgTranslation;
+  private boolean inactive;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The UCSBOrganizationRepository is a repository for UCSBOrganization entities.
+ */
+
+@Repository
+public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, String> {
+  
+}

--- a/src/main/resources/db/migration/changes/UCSBOrganizations.json
+++ b/src/main/resources/db/migration/changes/UCSBOrganizations.json
@@ -1,0 +1,61 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "UCSBOrganization-1",
+          "author": "yuecao365",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBORGANIZATION"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "UCSBORGANIZATIONS_PK"
+                      },
+                      "name": "ORG_CODE",
+                      "type": "VARCHAR(10)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "ORG_TRANSLATION_SHORT",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "ORG_TRANSLATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "INACTIVE",
+                      "type": "BOOLEAN"
+                    }
+                  }
+                ],
+                "tableName": "UCSBORGANIZATION"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -1,0 +1,323 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@WebMvcTest(controllers = UCSBOrganizationController.class)
+@Import(TestConfig.class)
+public class UCSBOrganizationControllerTests extends ControllerTestCase {
+
+        @MockBean
+        UCSBOrganizationRepository ucsbOrganizationRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Authorization tests for /api/ucsborganization/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/ucsborganization/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/ucsborganization/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+
+                // Authorization tests for /api/ucsborganization/post
+        // (Perhaps should also have these for put and delete)
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ucsborganization/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ucsborganization/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_ucsborganization() throws Exception {
+
+                // arrange
+
+                UCSBOrganization ucsbOrganization1 = UCSBOrganization.builder()
+                        .orgCode("ZPR")
+                        .orgTranslationShort("ZETA PHI RHO")
+                        .orgTranslation("ZETA PHI RHO")
+                        .inactive(false)
+                        .build();
+
+                UCSBOrganization ucsbOrganization2 = UCSBOrganization.builder()
+                        .orgCode("SKY")
+                        .orgTranslationShort("SKYDIVING CLUB")
+                        .orgTranslation("SKYDIVING CLUB AT UCSB")
+                        .inactive(true)
+                        .build();
+
+                ArrayList<UCSBOrganization> expectedUCSBOrganization = new ArrayList<>();
+                expectedUCSBOrganization.addAll(Arrays.asList(ucsbOrganization1, ucsbOrganization2));
+
+                when(ucsbOrganizationRepository.findAll()).thenReturn(expectedUCSBOrganization);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsborganization/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedUCSBOrganization);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_ucsborganization() throws Exception {
+                // arrange
+
+                UCSBOrganization ucsbOrganization1 = UCSBOrganization.builder()
+                        .orgCode("ZPR")
+                        .orgTranslationShort("ZETA PHI RHO")
+                        .orgTranslation("ZETA PHI RHO")
+                        .inactive(true)
+                        .build();
+
+                when(ucsbOrganizationRepository.save(eq(ucsbOrganization1))).thenReturn(ucsbOrganization1);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/ucsborganization/post?orgCode=ZPR&orgTranslationShort=ZETA PHI RHO&orgTranslation=ZETA PHI RHO&inactive=true")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).save(eq(ucsbOrganization1));
+                String expectedJson = mapper.writeValueAsString(ucsbOrganization1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/ucsborganization?orgCode=ASDF"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(ucsbOrganizationRepository.findById(eq("ABCD"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsborganization?orgCode=ABCD"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findById(eq("ABCD"));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("UCSBOrganization with id ABCD not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_exist() throws Exception {
+
+                // arrange
+
+                UCSBOrganization ucsbOrganization1 = UCSBOrganization.builder()
+                        .orgCode("ZPR")
+                        .orgTranslationShort("ZETA PHI RHO")
+                        .orgTranslation("ZETA PHI RHO")
+                        .inactive(true)
+                        .build();
+
+                when(ucsbOrganizationRepository.findById(eq("ZPR"))).thenReturn(Optional.of(ucsbOrganization1));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsborganization?orgCode=ZPR"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findById(eq("ZPR"));
+                String expectedJson = mapper.writeValueAsString(ucsbOrganization1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+
+        }
+
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_ucsborganization() throws Exception {
+                // arrange
+
+                UCSBOrganization ucsbOrganizationOrig = UCSBOrganization.builder()
+                        .orgCode("ZPR")
+                        .orgTranslationShort("ZETA PHI RHO")
+                        .orgTranslation("ZETA PHI RHO")
+                        .inactive(true)
+                        .build();
+
+                UCSBOrganization ucsbOrganizationEdited = UCSBOrganization.builder()
+                        .orgCode("ZPR")
+                        .orgTranslationShort("SKYDIVING CLUB")
+                        .orgTranslation("SKYDIVING CLUB AT UCSB")
+                        .inactive(false)
+                        .build();
+
+
+                String requestBody = mapper.writeValueAsString(ucsbOrganizationEdited);
+
+                when(ucsbOrganizationRepository.findById(eq("ZPR"))).thenReturn(Optional.of(ucsbOrganizationOrig));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ucsborganization?orgCode=ZPR")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("ZPR");
+                verify(ucsbOrganizationRepository, times(1)).save(ucsbOrganizationEdited); // should be saved with correct user
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
+                // arrange
+
+                UCSBOrganization ucsbEditedOrganization = UCSBOrganization.builder()
+                        .orgCode("ZPR")
+                        .orgTranslationShort("ZETA PHI RHO")
+                        .orgTranslation("ZETA PHI RHO")
+                        .inactive(true)
+                        .build();
+
+
+                String requestBody = mapper.writeValueAsString(ucsbEditedOrganization);
+
+                when(ucsbOrganizationRepository.findById(eq("ZPR"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ucsborganization?orgCode=ZPR")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("ZPR");
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBOrganization with id ZPR not found", json.get("message"));
+
+        }
+
+
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_an_organization() throws Exception {
+                // arrange
+
+                UCSBOrganization ucsbOrganization1 = UCSBOrganization.builder()
+                        .orgCode("ZPR")
+                        .orgTranslationShort("ZETA PHI RHO")
+                        .orgTranslation("ZETA PHI RHO")
+                        .inactive(true)
+                        .build();
+
+                when(ucsbOrganizationRepository.findById(eq("ZPR"))).thenReturn(Optional.of(ucsbOrganization1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ucsborganization?orgCode=ZPR")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("ZPR");
+                verify(ucsbOrganizationRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBOrganization with id ZPR deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_ucsborganization_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(ucsbOrganizationRepository.findById(eq("ZPR"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ucsborganization?orgCode=ZPR")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("ZPR");
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBOrganization with id ZPR not found", json.get("message"));
+        }
+
+}


### PR DESCRIPTION
In this PR, we add fixtures for the UCSBOrganization table in the frontend code.

These will be used for tests and for storybook entries later on.